### PR TITLE
Construction from values and frame type variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the `construct_frame` function to construct a coordinate frame from values and a `CoordinateFrameType` variant.
+
 ## [0.5.0] - 2024-07-14
 
 [0.5.0]: https://github.com/sunsided/coordinate-frame/releases/tag/v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added the `construct_frame` function to construct a coordinate frame from values and a `CoordinateFrameType` variant.
+- Added the `new_from` function to a coordinate frame to simplify access to `construct_frame`.
 
 ## [0.5.0] - 2024-07-14
 

--- a/crates/coordinate-frame/src/lib.rs
+++ b/crates/coordinate-frame/src/lib.rs
@@ -217,9 +217,8 @@ mod tests {
 
     #[test]
     fn construct() {
-        let ned: NorthEastDown<_> =
-            construct_frame(CoordinateFrameType::SouthWestUp, 1.0, 2.0, 3.0)
-                .expect("invalid conversion");
+        let ned = NorthEastDown::new_from(CoordinateFrameType::SouthWestUp, 1.0, 2.0, 3.0)
+            .expect("invalid conversion");
         assert_eq!(ned.north(), -1.0);
         assert_eq!(ned.east(), -2.0);
         assert_eq!(ned.down(), -3.0);

--- a/crates/coordinate-frame/src/lib.rs
+++ b/crates/coordinate-frame/src/lib.rs
@@ -169,7 +169,7 @@ pub enum ParseCoordinateFrameError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{EastNorthUp, NorthEastDown, NorthEastUp, SouthWestUp};
+    use crate::*;
 
     #[test]
     fn neu_to_ned() {
@@ -213,6 +213,16 @@ mod tests {
         assert_eq!(ned2.north(), 2.0);
         assert_eq!(ned2.east(), 4.0);
         assert_eq!(ned2.down(), -6.0);
+    }
+
+    #[test]
+    fn construct() {
+        let ned: NorthEastDown<_> =
+            construct_frame(CoordinateFrameType::SouthWestUp, 1.0, 2.0, 3.0)
+                .expect("invalid conversion");
+        assert_eq!(ned.north(), -1.0);
+        assert_eq!(ned.east(), -2.0);
+        assert_eq!(ned.down(), -3.0);
     }
 
     #[test]

--- a/proc-macros/coordinate-frame-derive/src/lib.rs
+++ b/proc-macros/coordinate-frame-derive/src/lib.rs
@@ -384,6 +384,15 @@ fn process_unit_enum(enum_name: Ident, data_enum: DataEnum) -> TokenStream {
                         Self([#first_component, #second_component, #third_component])
                     }
 
+                    /// Constructs a new instance from values in the specified coordinate frame.
+                    /// See the [`construct_frame`] function for more information.
+                    pub fn new_from(frame: CoordinateFrameType, x: T, y: T, z: T) -> Option<Self>
+                    where
+                        T: Copy + SaturatingNeg<Output = T>
+                    {
+                        construct_frame(frame, x, y, z)
+                    }
+
                     /// Constructs an instance from an array.
                     ///
                     /// Be mindful not to directly pass a different coordinate frame into


### PR DESCRIPTION
TL;DR, this:

```rust
let ned = NorthEastDown::new_from(CoordinateFrameType::SouthWestUp, 1.0, 2.0, 3.0)
    .expect("invalid conversion");
assert_eq!(ned.north(), -1.0);
assert_eq!(ned.east(), -2.0);
assert_eq!(ned.down(), -3.0);
```